### PR TITLE
[Mod/#84] bitmap compression 개선

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation(project(":core:datastore"))
     implementation(libs.paging)
     implementation(libs.okhttp)
+    implementation(libs.androidx.exifinterface)
 }

--- a/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultPostingRepository.kt
+++ b/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultPostingRepository.kt
@@ -2,8 +2,8 @@ package com.teamwable.data.repositoryimpl
 
 import android.content.ContentResolver
 import com.teamwable.data.repository.PostingRepository
+import com.teamwable.data.util.createImagePart
 import com.teamwable.network.datasource.PostingService
-import com.teamwable.network.util.createImagePart
 import com.teamwable.network.util.handleThrowable
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody

--- a/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultProfileRepository.kt
+++ b/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultProfileRepository.kt
@@ -5,12 +5,12 @@ import com.teamwable.data.mapper.toData.toReportDto
 import com.teamwable.data.mapper.toModel.toMemberDataModel
 import com.teamwable.data.mapper.toModel.toProfile
 import com.teamwable.data.repository.ProfileRepository
+import com.teamwable.data.util.createImagePart
 import com.teamwable.model.Profile
 import com.teamwable.model.profile.MemberDataModel
 import com.teamwable.model.profile.MemberInfoEditModel
 import com.teamwable.network.datasource.ProfileService
 import com.teamwable.network.dto.request.RequestWithdrawalDto
-import com.teamwable.network.util.createImagePart
 import com.teamwable.network.util.handleThrowable
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody

--- a/core/data/src/main/java/com/teamwable/data/util/ContentUriRequestBody.kt
+++ b/core/data/src/main/java/com/teamwable/data/util/ContentUriRequestBody.kt
@@ -41,53 +41,55 @@ class ContentUriRequestBody(
     }
 
     private fun compressBitmap() {
-        var originalBitmap: Bitmap? = null
+        var originalBitmap: Bitmap
         val exif: ExifInterface
 
         contentResolver.openInputStream(uri).use { inputStream ->
             if (inputStream == null) return
             exif = ExifInterface(inputStream)
-        }
 
-        // 이미지 크기를 계산하여 imageSizeMb 선언
-        val imageSizeMb = size / (1024.0 * 1024.0)
-
-        contentResolver.openInputStream(uri).use { inputStream ->
-            if (inputStream == null) return
-            // 이미지 크기를 계산하여 3MB를 초과하는 경우에만 inSampleSize 설정
+            val imageSizeMb = size / (1024.0 * 1024.0)
             val option = BitmapFactory.Options().apply {
-                if (imageSizeMb >= 5) {
+                if (imageSizeMb >= IMAGE_SIZE_MB) {
                     inSampleSize = calculateInSampleSize(this, MAX_WIDTH, MAX_HEIGHT)
                 }
             }
-            originalBitmap = BitmapFactory.decodeStream(inputStream, null, option)
+
+            originalBitmap =
+                BitmapFactory.decodeStream(contentResolver.openInputStream(uri), null, option)
+                    ?: return
         }
 
-        originalBitmap?.let { bitmap ->
-            val orientation = exif.getAttributeInt(
-                ExifInterface.TAG_ORIENTATION,
-                ExifInterface.ORIENTATION_NORMAL,
+        val orientation = exif.getAttributeInt(
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.ORIENTATION_NORMAL,
+        )
+        val rotatedBitmap = when (orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> rotateBitmap(originalBitmap, 90f)
+            ExifInterface.ORIENTATION_ROTATE_180 -> rotateBitmap(originalBitmap, 180f)
+            ExifInterface.ORIENTATION_ROTATE_270 -> rotateBitmap(originalBitmap, 270f)
+            else -> originalBitmap
+        }
+
+        val outputStream = ByteArrayOutputStream()
+        val imageSizeMb = size / (MAX_WIDTH * MAX_HEIGHT.toDouble())
+
+        outputStream.use {
+            val compressRate = ((IMAGE_SIZE_MB / imageSizeMb) * 100).toInt()
+            rotatedBitmap.compress(
+                Bitmap.CompressFormat.JPEG,
+                if (imageSizeMb >= IMAGE_SIZE_MB) compressRate else 100,
+                it,
             )
-            val rotatedBitmap = when (orientation) {
-                ExifInterface.ORIENTATION_ROTATE_90 -> rotateBitmap(bitmap, 90f)
-                ExifInterface.ORIENTATION_ROTATE_180 -> rotateBitmap(bitmap, 180f)
-                ExifInterface.ORIENTATION_ROTATE_270 -> rotateBitmap(bitmap, 270f)
-                else -> bitmap
-            }
-
-            val outputStream = ByteArrayOutputStream()
-            val compressRate = if (imageSizeMb >= IMG_SIZE) {
-                ((100 * IMG_SIZE) / imageSizeMb).coerceIn(0.0, 100.0).toInt() // 압축률을 0에서 100 사이로 제한
-            } else {
-                75 // 기본 압축률
-            }
-
-            outputStream.use { stream ->
-                rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, compressRate, stream)
-            }
-            compressedImage = outputStream.toByteArray()
-            size = compressedImage?.size?.toLong() ?: -1L
         }
+
+        compressedImage = outputStream.toByteArray()
+        size = compressedImage?.size?.toLong() ?: -1L
+
+        if (rotatedBitmap != originalBitmap) {
+            originalBitmap.recycle()
+        }
+        rotatedBitmap.recycle()
     }
 
     private fun rotateBitmap(bitmap: Bitmap, degrees: Float): Bitmap {
@@ -131,7 +133,7 @@ class ContentUriRequestBody(
     fun toMultiPartData(name: String) = MultipartBody.Part.createFormData(name, getFileName(), this)
 
     companion object {
-        private const val IMG_SIZE = 5
+        const val IMAGE_SIZE_MB = 1
         const val MAX_WIDTH = 1024
         const val MAX_HEIGHT = 1024
     }

--- a/core/data/src/main/java/com/teamwable/data/util/ContentUriRequestBody.kt
+++ b/core/data/src/main/java/com/teamwable/data/util/ContentUriRequestBody.kt
@@ -1,4 +1,4 @@
-package com.teamwable.network.util
+package com.teamwable.data.util
 
 import android.content.ContentResolver
 import android.graphics.Bitmap

--- a/core/data/src/main/java/com/teamwable/data/util/createImagePart.kt
+++ b/core/data/src/main/java/com/teamwable/data/util/createImagePart.kt
@@ -1,4 +1,4 @@
-package com.teamwable.network.util
+package com.teamwable.data.util
 
 import android.content.ContentResolver
 import android.net.Uri

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -32,7 +32,6 @@ android {
 dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:datastore"))
-    implementation(libs.androidx.exifinterface)
     implementation(libs.paging)
     implementation(libs.process.phoenix)
 }

--- a/feature/main/src/main/java/com/teamwable/main/di/IntentModule.kt
+++ b/feature/main/src/main/java/com/teamwable/main/di/IntentModule.kt
@@ -1,7 +1,7 @@
 package com.teamwable.main.di
 
-import com.teamwable.common.intentprovider.IntentProvider
 import com.teamwable.common.di.MAIN
+import com.teamwable.common.intentprovider.IntentProvider
 import com.teamwable.main.intentprovider.DefaultIntentProvider
 import dagger.Binds
 import dagger.Module
@@ -12,8 +12,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class IntentModule {
-  @Binds
-  @Singleton
-  @MAIN
-  abstract fun bindsIntentProvider(intentProvider: DefaultIntentProvider): IntentProvider
+    @Binds
+    @Singleton
+    @MAIN
+    abstract fun bindsIntentProvider(intentProvider: DefaultIntentProvider): IntentProvider
 }


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #84 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- bitmap compression 개선

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
현생 이슈로 테스트 코드는 다음에..

추가로 contentUriRequestBody와 creatImagePart 확장함수는 data 모듈로 옮겼습니다!
내부의 content reslover를 사용하기에 data모듈이 적합하다 느꼈습니다!
추후에 unit test시에도 data 모듈에서 하는게 맞는 거 같아요

비슷한 예로 generic panging source도 data모듈로 이동시키는건 어떨까요?
network data  모두 paging 라이브러리를 의존해서 data 모듈에 존재시키면
network모듈에서 불필요한 의존성을 제거할 수 ㅣ있을 것 같습니다!