### PR TITLE
[Hotfix/#103] in app error, like.. etc

### DIFF
--- a/core/common/src/main/java/com/teamwable/common/util/AmplitudeTag.kt
+++ b/core/common/src/main/java/com/teamwable/common/util/AmplitudeTag.kt
@@ -10,7 +10,7 @@ object AmplitudeSignUpTag {
     const val CLICK_DETOUR_TEAM_SIGNUP = "click_detour_team_signup"
     const val CLICK_NEXT_TEAM_SIGNUP = "click_next_team_signup"
     const val CLICK_CHANGE_PICTURE_PROFILE_SIGNUP = "click_change_picture_profile_signup"
-    const val CLICK_ADD_PICTURE_PROFILE_SIGNUP = "k_add_picture_profile_signup"
+    const val CLICK_ADD_PICTURE_PROFILE_SIGNUP = "click_add_picture_profile_signup"
     const val CLICK_NEXT_PROFILE_SIGNUP = "click_next_profile_signup"
     const val CLICK_COMPLETE_TNC_SIGNUP = "click_complete_tnc_signup"
     const val CLICK_JOIN_POPUP_SIGNUP = "click_join_popup_signup"

--- a/core/ui/src/main/java/com/teamwable/ui/extensions/ContextExt.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/extensions/ContextExt.kt
@@ -124,3 +124,22 @@ fun Context.restartApp() {
     intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
     startActivity(intent)
 }
+
+fun Context.showAlertDialog(
+    title: String,
+    message: String,
+    positiveButtonText: String,
+    negativeButtonText: String,
+    onPositiveClick: () -> Unit,
+) {
+    val builder = AlertDialog.Builder(this)
+    builder.setTitle(title)
+        .setMessage(message)
+        .setPositiveButton(positiveButtonText) { dialog, _ ->
+            dialog.dismiss()
+            onPositiveClick()
+        }
+        .setNegativeButton(negativeButtonText) { dialog, _ -> dialog.dismiss() }
+
+    builder.create().show()
+}

--- a/core/ui/src/main/java/com/teamwable/ui/util/SingleEventHandler.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/util/SingleEventHandler.kt
@@ -21,7 +21,7 @@ class SingleEventHandler private constructor() {
     }
 
     companion object {
-        private const val DEBOUNCE_DELAY = 500L
+        private const val DEBOUNCE_DELAY = 200L
 
         fun from(): SingleEventHandler = SingleEventHandler()
     }

--- a/feature/main/src/main/java/com/teamwable/main/AppUpdateHandler.kt
+++ b/feature/main/src/main/java/com/teamwable/main/AppUpdateHandler.kt
@@ -1,63 +1,28 @@
 package com.teamwable.main
 
-import android.content.Context
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
-import androidx.appcompat.app.AlertDialog
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
-import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.UpdateAvailability
 
-class AppUpdateHandler(private val context: Context) {
-    private lateinit var appUpdateManager: AppUpdateManager
-
-    fun checkForAppUpdate(activityResultLauncher: ActivityResultLauncher<IntentSenderRequest>) {
-        appUpdateManager = AppUpdateManagerFactory.create(context)
+class AppUpdateHandler(private val appUpdateManager: AppUpdateManager) {
+    fun checkForAppUpdate(onUpdateAvailable: (AppUpdateInfo) -> Unit) {
         val appUpdateInfoTask = appUpdateManager.appUpdateInfo
 
         appUpdateInfoTask.addOnSuccessListener { appUpdateInfo ->
             if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE)
-                showUpdateDialog(appUpdateInfo, activityResultLauncher)
+                onUpdateAvailable(appUpdateInfo)
         }
     }
 
-    private fun showUpdateDialog(appUpdateInfo: AppUpdateInfo, activityResultLauncher: ActivityResultLauncher<IntentSenderRequest>) {
-        val builder = AlertDialog.Builder(context)
-        builder.setTitle(context.getString(R.string.label_in_app_update_title))
-            .setMessage(context.getString(R.string.label_in_app_update_content))
-            .setPositiveButton(context.getString(R.string.label_in_app_update_yes)) { dialog, _ ->
-                dialog.dismiss()
-                startUpdate(appUpdateInfo, activityResultLauncher)
-            }
-            .setNegativeButton(context.getString(R.string.label_in_app_update_next)) { dialog, _ ->
-                dialog.dismiss()
-            }
-
-        val dialog = builder.create()
-        dialog.show()
-    }
-
-    private fun startUpdate(appUpdateInfo: AppUpdateInfo, activityResultLauncher: ActivityResultLauncher<IntentSenderRequest>) {
+    fun startUpdate(appUpdateInfo: AppUpdateInfo, activityResultLauncher: ActivityResultLauncher<IntentSenderRequest>) {
         appUpdateManager.startUpdateFlowForResult(
             appUpdateInfo,
             activityResultLauncher,
             AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
         )
-    }
-
-    fun resumeUpdateIfNeeded(activityResultLauncher: ActivityResultLauncher<IntentSenderRequest>) {
-        appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
-            if (appUpdateInfo.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
-                // In-app update가 이미 실행 중이면, 업데이트를 다시 시작
-                appUpdateManager.startUpdateFlowForResult(
-                    appUpdateInfo,
-                    activityResultLauncher,
-                    AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
-                )
-            }
-        }
     }
 }

--- a/feature/main/src/main/java/com/teamwable/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/teamwable/main/MainActivity.kt
@@ -57,10 +57,12 @@ class MainActivity : AppCompatActivity(), Navigation {
         }
 
     private val installStateUpdatedListener = InstallStateUpdatedListener { state ->
-        if (state.installStatus() == InstallStatus.DOWNLOADED) Timber.i("Download Complete")
-        lifecycleScope.launch {
-            delay(5000)
-            appUpdateManager.completeUpdate()
+        if (state.installStatus() == InstallStatus.DOWNLOADED) {
+            Timber.i("Download Complete")
+            lifecycleScope.launch {
+                delay(5000)
+                appUpdateManager.completeUpdate()
+            }
         }
     }
 
@@ -74,7 +76,13 @@ class MainActivity : AppCompatActivity(), Navigation {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        appUpdateManager.unregisterListener(installStateUpdatedListener)
+    }
+
     private fun setInAppUpdate() {
+        appUpdateManager.registerListener(installStateUpdatedListener)
         appUpdateHelper = AppUpdateHandler(appUpdateManager).apply {
             checkForAppUpdate { appUpdateInfo -> showUpdateDialog(appUpdateInfo) }
         }

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -18,5 +18,5 @@
     <string name="label_in_app_update_content">와블이 새롭게 업그레이드 되었어요. 업데이트를 통해 최신 버전으로 즐겨보세요.</string>
     <string name="label_in_app_update_yes">업데이트 하기</string>
     <string name="label_in_app_update_next">다음에</string>
-    <string name="label_in_app_update_success">업데이트되었습니다. 앱을 재시작 해주세요.</string>
+    <string name="label_in_app_update_success">업데이트 중 입니다.</string>
 </resources>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -18,5 +18,5 @@
     <string name="label_in_app_update_content">와블이 새롭게 업그레이드 되었어요. 업데이트를 통해 최신 버전으로 즐겨보세요.</string>
     <string name="label_in_app_update_yes">업데이트 하기</string>
     <string name="label_in_app_update_next">다음에</string>
-    <string name="label_in_app_update_success">업데이트 중 입니다.</string>
+    <string name="label_in_app_update_success">업데이트 진행 중 : 화면 이탈 시 업데이트가 취소 될 수 있습니다.</string>
 </resources>

--- a/feature/profile/src/main/java/com/teamwable/profile/profile/BindingProfileFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profile/BindingProfileFragment.kt
@@ -37,7 +37,8 @@ abstract class BindingProfileFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding.appbarProfileInfo.removeOnOffsetChangedListener(offsetChangedListener)
+        if (this::offsetChangedListener.isInitialized)
+            binding.appbarProfileInfo.removeOnOffsetChangedListener(offsetChangedListener)
         _binding = null
     }
 

--- a/feature/profile/src/main/java/com/teamwable/profile/profile/BindingProfileFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profile/BindingProfileFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.google.android.material.appbar.AppBarLayout
 import com.teamwable.model.Profile
 import com.teamwable.profile.R
 import com.teamwable.profile.databinding.FragmentProfileBinding
@@ -23,6 +24,8 @@ abstract class BindingProfileFragment : Fragment() {
     protected val binding: FragmentProfileBinding
         get() = requireNotNull(_binding) { "ViewBinding is not initialized" }
 
+    private lateinit var offsetChangedListener: AppBarLayout.OnOffsetChangedListener
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -34,6 +37,7 @@ abstract class BindingProfileFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        binding.appbarProfileInfo.removeOnOffsetChangedListener(offsetChangedListener)
         _binding = null
     }
 
@@ -43,7 +47,15 @@ abstract class BindingProfileFragment : Fragment() {
         tvProfileNickname.text = data.nickName
         tvProfileInfo.text = getString(R.string.label_profile_info, data.teamTag.ifBlank { TeamTag.LCK.name }, data.lckYears)
         tvProfileGhostPercentage.text = getString(R.string.label_ghost_percentage, data.ghost)
+        setSwipeLayout()
         setGhostProgress(data.ghost)
+    }
+
+    private fun setSwipeLayout() {
+        offsetChangedListener = AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
+            binding.layoutProfileSwipe.isEnabled = verticalOffset == 0
+        }
+        binding.appbarProfileInfo.addOnOffsetChangedListener(offsetChangedListener)
     }
 
     private fun setGhostProgress(percentage: Int) {

--- a/feature/profile/src/main/java/com/teamwable/profile/profile/ProfileAuthFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profile/ProfileAuthFragment.kt
@@ -6,7 +6,6 @@ import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.teamwable.model.Profile
 import com.teamwable.model.profile.MemberInfoEditModel
@@ -81,12 +80,6 @@ class ProfileAuthFragment : BindingProfileFragment() {
     }
 
     private fun setSwipeLayout() {
-        binding.appbarProfileInfo.addOnOffsetChangedListener(
-            AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
-                binding.layoutProfileSwipe.isEnabled = verticalOffset == 0
-            },
-        )
-
         binding.layoutProfileSwipe.setOnRefreshListener {
             binding.layoutProfileSwipe.isRefreshing = false
             viewModel.fetchAuthId()

--- a/feature/profile/src/main/java/com/teamwable/profile/profile/ProfileAuthFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profile/ProfileAuthFragment.kt
@@ -13,6 +13,7 @@ import com.teamwable.profile.hamburger.ProfileHamburgerBottomSheet
 import com.teamwable.profile.profiletabs.ProfilePagerStateAdapter
 import com.teamwable.profile.profiletabs.ProfileTabType
 import com.teamwable.ui.extensions.parcelable
+import com.teamwable.ui.extensions.setOnDuplicateBlockClick
 import com.teamwable.ui.extensions.stringOf
 import com.teamwable.ui.extensions.viewLifeCycle
 import com.teamwable.ui.extensions.viewLifeCycleScope
@@ -44,7 +45,7 @@ class ProfileAuthFragment : BindingProfileFragment() {
     }
 
     private fun initAppbarHamburgerClickListener() {
-        binding.viewProfileAppbar.btnProfileAppbarHamburger.setOnClickListener {
+        binding.viewProfileAppbar.btnProfileAppbarHamburger.setOnDuplicateBlockClick {
             ProfileHamburgerBottomSheet().show(childFragmentManager, PROFILE_HAMBURGER_BOTTOM_SHEET)
         }
     }

--- a/feature/profile/src/main/java/com/teamwable/profile/profile/ProfileMemberFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profile/ProfileMemberFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.teamwable.model.Profile
 import com.teamwable.profile.profiletabs.ProfilePagerStateAdapter
@@ -63,12 +62,6 @@ class ProfileMemberFragment : BindingProfileFragment() {
     }
 
     private fun setSwipeLayout() {
-        binding.appbarProfileInfo.addOnOffsetChangedListener(
-            AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
-                binding.layoutProfileSwipe.isEnabled = verticalOffset == 0
-            },
-        )
-
         binding.layoutProfileSwipe.setOnRefreshListener {
             binding.layoutProfileSwipe.isRefreshing = false
             viewModel.fetchProfileInfo(userId)


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #103 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 좋아요 디바운스 딜레이 타임 줄이기
- 프로필 swipe listener 해제 이슈
- 프로필 햄버거 바텀 시트 중복 이슈
- 앰플 태그 잘 못 기입된 k -> click
- in app update

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
#### in app update
https://github.com/user-attachments/assets/06b93545-cfe9-4627-9f57-45285753fc0f

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
좋아요 누르고 바로 홈 상세로 이동할 경우 가끔 좋아요 api 응답이 오기 전에, 상세 api 응답이 먼저 와서
반영이 안되어 있는 오류가 있습니다 => 기존에 발생하던 문제
디바운스 딜레이를 줄이긴 해서 문제 발생이 빈도가 덜 하긴합니다. 응답 오기 전에 임시 state 로컬에서 반영하는 방법 .. 등 고민을 조금 더 해보고 고쳐볼게욥

