### PR TITLE
[Feature/#113] news탭 compose setting

### DIFF
--- a/core/designsystem/src/main/java/com/teamwable/designsystem/extension/composable/ImageExt.kt
+++ b/core/designsystem/src/main/java/com/teamwable/designsystem/extension/composable/ImageExt.kt
@@ -1,0 +1,9 @@
+package com.teamwable.designsystem.extension.composable
+
+import androidx.annotation.DrawableRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+
+@Composable
+fun toImageVector(@DrawableRes id: Int): ImageVector = ImageVector.vectorResource(id = id)

--- a/core/designsystem/src/main/java/com/teamwable/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/teamwable/designsystem/theme/Theme.kt
@@ -8,8 +8,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
-import com.teamwable.designsystem.extension.system.SetLightNavigationBar
-import com.teamwable.designsystem.extension.system.SetStatusBarColor
 
 private val LocalWableColors = staticCompositionLocalOf<WableColors> {
     error("No WableColors provided")
@@ -59,8 +57,6 @@ fun WableTheme(
 ) {
     val colors = wableLightColors()
     val typography = wableTypography()
-    SetStatusBarColor(color = colors.white)
-    SetLightNavigationBar()
     ProvideWableColorsAndTypography(colors, typography) {
         MaterialTheme(
             content = content, colorScheme = lightColorScheme(colors),

--- a/feature/main-compose/src/main/java/com/teamwable/main_compose/MainComposeActivity.kt
+++ b/feature/main-compose/src/main/java/com/teamwable/main_compose/MainComposeActivity.kt
@@ -7,7 +7,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.teamwable.common.di.MAIN
 import com.teamwable.common.intentprovider.IntentProvider
+import com.teamwable.designsystem.extension.system.SetLightNavigationBar
+import com.teamwable.designsystem.extension.system.SetStatusBarColor
 import com.teamwable.designsystem.theme.WableTheme
+import com.teamwable.designsystem.theme.WableTheme.colors
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -24,6 +27,8 @@ class MainComposeActivity : ComponentActivity() {
         setContent {
             WableTheme {
                 val navigator: MainNavigator = rememberMainNavigator()
+                SetStatusBarColor(color = colors.white)
+                SetLightNavigationBar()
                 MainScreen(
                     navigator = navigator,
                     intentProvider = intentProvider,

--- a/feature/news/build.gradle.kts
+++ b/feature/news/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     id("com.teamwable.wable.feature")
     id("com.teamwable.wable.test")
+    id("com.teamwable.wable.compose.feature")
 }
 android {
     namespace = "com.teamwable.news"
@@ -9,9 +10,7 @@ android {
 
 dependencies {
     implementation(project(":core:ui"))
-    implementation(project(":core:common"))
-    implementation(project(":core:model"))
-    implementation(project(":core:data"))
+    implementation(project(":core:designsystem"))
 
     // AndroidX
     implementation(libs.fragment.ktx)

--- a/feature/news/build.gradle.kts
+++ b/feature/news/build.gradle.kts
@@ -10,7 +10,6 @@ android {
 
 dependencies {
     implementation(project(":core:ui"))
-    implementation(project(":core:designsystem"))
 
     // AndroidX
     implementation(libs.fragment.ktx)

--- a/feature/news/src/main/java/com/teamwable/news/model/NewsInfoModel.kt
+++ b/feature/news/src/main/java/com/teamwable/news/model/NewsInfoModel.kt
@@ -1,0 +1,9 @@
+package com.teamwable.news.model
+
+data class NewsInfoModel(
+    val newsId: Int,
+    val newsTitle: String,
+    val newsText: String,
+    val newsImage: String,
+    val time: String,
+)

--- a/feature/news/src/main/java/com/teamwable/news/news/NewsNewsFragment.kt
+++ b/feature/news/src/main/java/com/teamwable/news/news/NewsNewsFragment.kt
@@ -1,5 +1,7 @@
 package com.teamwable.news.news
 
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.teamwable.designsystem.theme.WableTheme
 import com.teamwable.news.databinding.FragmentNewsNewsBinding
 import com.teamwable.ui.base.BindingFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -7,6 +9,12 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class NewsNewsFragment : BindingFragment<FragmentNewsNewsBinding>(FragmentNewsNewsBinding::inflate) {
     override fun initView() {
-
+        binding.composeView.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WableTheme {
+                }
+            }
+        }
     }
 }

--- a/feature/news/src/main/java/com/teamwable/news/news/NewsNewsRoute.kt
+++ b/feature/news/src/main/java/com/teamwable/news/news/NewsNewsRoute.kt
@@ -1,0 +1,22 @@
+package com.teamwable.news.news
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.teamwable.designsystem.theme.WableTheme
+
+@Composable
+fun NewsNewsRoute() {
+}
+
+@Composable
+fun NewsNewsScreen(){
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GreetingPreview() {
+    WableTheme {
+        NewsNewsScreen()
+    }
+}

--- a/feature/news/src/main/res/layout/fragment_news_news.xml
+++ b/feature/news/src/main/res/layout/fragment_news_news.xml
@@ -4,10 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="news"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/feature/onboarding/src/main/java/com/teamwable/onboarding/firstlckwatch/FirstLckWatchScreen.kt
+++ b/feature/onboarding/src/main/java/com/teamwable/onboarding/firstlckwatch/FirstLckWatchScreen.kt
@@ -34,7 +34,7 @@ import com.teamwable.model.profile.MemberInfoEditModel
 import com.teamwable.onboarding.R
 import com.teamwable.onboarding.firstlckwatch.component.WableExposedDropdownBox
 import com.teamwable.onboarding.firstlckwatch.model.FirstLckWatchSideEffect
-import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun FirstLckWatchRoute(
@@ -70,7 +70,7 @@ fun FirstLckWatchScreen(
 ) {
     SetStatusBarColor(color = WableTheme.colors.white)
 
-    val options = (2012..2024).toPersistentList()
+    val options = (2012..2024).toImmutableList()
 
     var expanded by remember { mutableStateOf(false) }
     var selectedIndex by rememberSaveable { mutableIntStateOf(options.lastIndex) }

--- a/feature/onboarding/src/main/java/com/teamwable/onboarding/firstlckwatch/component/WableExposedDropdownBox.kt
+++ b/feature/onboarding/src/main/java/com/teamwable/onboarding/firstlckwatch/component/WableExposedDropdownBox.kt
@@ -25,12 +25,12 @@ import androidx.compose.ui.unit.dp
 import com.teamwable.designsystem.component.card.WableCustomCardWithStroke
 import com.teamwable.designsystem.extension.modifier.noRippleClickable
 import com.teamwable.designsystem.theme.WableTheme
-import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun WableExposedDropdownBox(
-    options: PersistentList<Int>,
+    options: ImmutableList<Int>,
     expanded: Boolean = false,
     selectedIndex: Int = 0,
     listState: LazyListState,
@@ -80,7 +80,10 @@ fun WableExposedDropdownBox(
                     contentPadding = PaddingValues(vertical = 4.dp),
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    itemsIndexed(options) { index, year ->
+                    itemsIndexed(
+                        items = options,
+                        key = { _, year -> year },
+                    ) { index, year ->
                         LckYearDropdownItem(
                             year = year.toString(),
                             onClick = {

--- a/feature/onboarding/src/main/java/com/teamwable/onboarding/selectlckteam/SelectLckTeamScreen.kt
+++ b/feature/onboarding/src/main/java/com/teamwable/onboarding/selectlckteam/SelectLckTeamScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -125,7 +125,10 @@ fun SelectLckTeamScreen(
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 modifier = Modifier.padding(top = 18.dp),
             ) {
-                itemsIndexed(shuffledTeams) { index, team ->
+                items(
+                    items = shuffledTeams,
+                    key = { team -> team.teamName },
+                ) { team ->
                     // 팀이 선택된 상태인지 확인
                     val isSelected = team == selectedTeam
                     LckTeamItem(


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #이슈번호

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- news탭 compose setting
- NewsInfoModel

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
![image](https://github.com/user-attachments/assets/499dcb50-e479-447d-bab1-d93321550164)


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
Dto는 달라도 NewsInfoModel은 공지사항에서 사용되는 model이랑 같아서 공통으로 써도 될거 같은데 네이밍만 바꿔서 같이 쓸까요?