### PR TITLE
Feature/#121 news number api

### DIFF
--- a/core/data/src/main/java/com/teamwable/data/repository/NewsRepository.kt
+++ b/core/data/src/main/java/com/teamwable/data/repository/NewsRepository.kt
@@ -16,4 +16,6 @@ interface NewsRepository {
     fun getNewsInfo(): Flow<PagingData<NewsInfoModel>>
 
     fun getNoticeInfo(): Flow<PagingData<NewsInfoModel>>
+
+    suspend fun getNumber(): Result<Map<String, Int>>
 }

--- a/core/data/src/main/java/com/teamwable/data/repository/UserInfoRepository.kt
+++ b/core/data/src/main/java/com/teamwable/data/repository/UserInfoRepository.kt
@@ -19,6 +19,10 @@ interface UserInfoRepository {
 
     fun getIsAdmin(): Flow<Boolean>
 
+    fun getNewsNumber(): Flow<Int>
+
+    fun getNoticeNumber(): Flow<Int>
+
     suspend fun saveAccessToken(accessToken: String)
 
     suspend fun saveRefreshToken(refreshToken: String)
@@ -34,6 +38,10 @@ interface UserInfoRepository {
     suspend fun saveIsPushAlarmAllowed(isPushAlarmAllowed: Boolean)
 
     suspend fun saveIsAdmin(isAdmin: Boolean)
+
+    suspend fun saveNewsNumber(newsNumber: Int)
+
+    suspend fun saveNoticeNumber(noticeNumber: Int)
 
     suspend fun clearAll()
 

--- a/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultNewsRepository.kt
+++ b/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultNewsRepository.kt
@@ -61,4 +61,13 @@ internal class DefaultNewsRepository @Inject constructor(
             pagingData.map { it.toNoticeInfoModel() }
         }
     }
+
+    override suspend fun getNumber(): Result<Map<String, Int>> {
+        return runCatching {
+            mapOf(
+                "news" to newsService.getNumber().data.newsNumber,
+                "notice" to newsService.getNumber().data.noticeNumber
+            )
+        }.onFailure { return it.handleThrowable() }
+    }
 }

--- a/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultUserInfoRepository.kt
+++ b/core/data/src/main/java/com/teamwable/data/repositoryimpl/DefaultUserInfoRepository.kt
@@ -32,6 +32,12 @@ internal class DefaultUserInfoRepository @Inject constructor(
     override fun getIsAdmin(): Flow<Boolean> =
         wablePreferencesDataSource.isAdmin
 
+    override fun getNewsNumber(): Flow<Int> =
+        wablePreferencesDataSource.newsNumber
+
+    override fun getNoticeNumber(): Flow<Int> =
+        wablePreferencesDataSource.noticeNumber
+
     override suspend fun saveAccessToken(accessToken: String) {
         wablePreferencesDataSource.updateAccessToken(accessToken)
     }
@@ -62,6 +68,14 @@ internal class DefaultUserInfoRepository @Inject constructor(
 
     override suspend fun saveIsAdmin(isAdmin: Boolean) {
         wablePreferencesDataSource.updateIsAdmin(isAdmin)
+    }
+
+    override suspend fun saveNewsNumber(newsNumber: Int) {
+        wablePreferencesDataSource.updateNewsNumber(newsNumber)
+    }
+
+    override suspend fun saveNoticeNumber(noticeNumber: Int) {
+        wablePreferencesDataSource.updateNoticeNumber(noticeNumber)
     }
 
     override suspend fun clearAll() {

--- a/core/datastore/src/main/java/com/teamwable/datastore/datasource/DefaultWablePreferenceDatasource.kt
+++ b/core/datastore/src/main/java/com/teamwable/datastore/datasource/DefaultWablePreferenceDatasource.kt
@@ -26,6 +26,8 @@ class DefaultWablePreferenceDatasource @Inject constructor(
         val MemberProfileUrl = stringPreferencesKey("memberProfileUrl")
         val IsPushAlarmAllowed = booleanPreferencesKey("isPushAlarmAllowed")
         val IsAdmin = booleanPreferencesKey("isAdmin")
+        val NewsNumber = intPreferencesKey("newsNumber")
+        val NoticeNumber = intPreferencesKey("noticeNumber")
     }
 
     override val accessToken: Flow<String> = dataStore.data
@@ -76,6 +78,18 @@ class DefaultWablePreferenceDatasource @Inject constructor(
             preferences[PreferencesKeys.IsAdmin] ?: false
         }
 
+    override val newsNumber: Flow<Int> = dataStore.data
+        .catch { handleError(it) }
+        .map { preferences ->
+            preferences[PreferencesKeys.NewsNumber] ?: -1
+        }
+
+    override val noticeNumber: Flow<Int> = dataStore.data
+        .catch { handleError(it) }
+        .map { preferences ->
+            preferences[PreferencesKeys.NoticeNumber] ?: -1
+        }
+
     override suspend fun updateAccessToken(accessToken: String) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.AccessToken] = accessToken
@@ -121,6 +135,18 @@ class DefaultWablePreferenceDatasource @Inject constructor(
     override suspend fun updateIsAdmin(isAdmin: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.IsAdmin] = isAdmin
+        }
+    }
+
+    override suspend fun updateNewsNumber(newsNumber: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.NewsNumber] = newsNumber
+        }
+    }
+
+    override suspend fun updateNoticeNumber(noticeNumber: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.NoticeNumber] = noticeNumber
         }
     }
 

--- a/core/datastore/src/main/java/com/teamwable/datastore/datasource/WablePreferencesDataSource.kt
+++ b/core/datastore/src/main/java/com/teamwable/datastore/datasource/WablePreferencesDataSource.kt
@@ -11,6 +11,8 @@ interface WablePreferencesDataSource {
     val memberProfileUrl: Flow<String>
     val isPushAlarmAllowed: Flow<Boolean>
     val isAdmin: Flow<Boolean>
+    val newsNumber: Flow<Int>
+    val noticeNumber: Flow<Int>
 
     suspend fun updateAccessToken(accessToken: String)
 
@@ -27,6 +29,10 @@ interface WablePreferencesDataSource {
     suspend fun updateIsPushAlarmAllowed(isPushAlarmAllowed: Boolean)
 
     suspend fun updateIsAdmin(isAdmin: Boolean)
+
+    suspend fun updateNewsNumber(newsNumber: Int)
+
+    suspend fun updateNoticeNumber(noticeNumber: Int)
 
     suspend fun clear()
 

--- a/core/network/src/main/java/com/teamwable/network/datasource/NewsService.kt
+++ b/core/network/src/main/java/com/teamwable/network/datasource/NewsService.kt
@@ -1,5 +1,6 @@
 package com.teamwable.network.datasource
 
+import com.teamwable.network.dto.response.main.ResponseNewsNumberDto
 import com.teamwable.network.dto.response.news.ResponseGameTypeDto
 import com.teamwable.network.dto.response.news.ResponseNewsInfoDto
 import com.teamwable.network.dto.response.news.ResponseNoticeInfoDto
@@ -28,4 +29,7 @@ interface NewsService {
     suspend fun getNoticeInfo(
         @Query(value = "cursor") contentId: Long = -1,
     ): BaseResponse<List<ResponseNoticeInfoDto>>
+
+    @GET("api/v1/information/number")
+    suspend fun getNumber(): BaseResponse<ResponseNewsNumberDto>
 }

--- a/core/network/src/main/java/com/teamwable/network/datasource/NotificationService.kt
+++ b/core/network/src/main/java/com/teamwable/network/datasource/NotificationService.kt
@@ -2,7 +2,7 @@ package com.teamwable.network.datasource
 
 import com.teamwable.network.dto.response.notification.ResponseInformationDto
 import com.teamwable.network.dto.response.notification.ResponseNotificationsDto
-import com.teamwable.network.dto.response.notification.ResponseNumberDto
+import com.teamwable.network.dto.response.notification.ResponseNotificationNumberDto
 import com.teamwable.network.util.BaseResponse
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -10,7 +10,7 @@ import retrofit2.http.Query
 
 interface NotificationService {
     @GET("api/v1/notification/number")
-    suspend fun getNumber(): BaseResponse<ResponseNumberDto>
+    suspend fun getNumber(): BaseResponse<ResponseNotificationNumberDto>
 
     @PATCH("api/v1/notification-check")
     suspend fun patchCheck(): BaseResponse<Unit>

--- a/core/network/src/main/java/com/teamwable/network/dto/response/main/ResponseNewsNumberDto.kt
+++ b/core/network/src/main/java/com/teamwable/network/dto/response/main/ResponseNewsNumberDto.kt
@@ -1,0 +1,12 @@
+package com.teamwable.network.dto.response.main
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseNewsNumberDto(
+    @SerialName("newsNumber")
+    val newsNumber: Int = 0,
+    @SerialName("noticeNumber")
+    val noticeNumber: Int = 0
+)

--- a/core/network/src/main/java/com/teamwable/network/dto/response/notification/ResponseNotificationNumberDto.kt
+++ b/core/network/src/main/java/com/teamwable/network/dto/response/notification/ResponseNotificationNumberDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ResponseNumberDto(
+data class ResponseNotificationNumberDto(
     @SerialName("notificationNumber")
     val notificationNumber: Int = 0
 )

--- a/feature/news/src/main/java/com/teamwable/news/NewsFragment.kt
+++ b/feature/news/src/main/java/com/teamwable/news/NewsFragment.kt
@@ -40,32 +40,39 @@ class NewsFragment : BindingFragment<FragmentNewsBinding>(FragmentNewsBinding::i
         viewModel.newsNumberUiState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
-                    val localNewsNumber = viewModel.getNewsNumberFromLocal()
-                    val localNoticeNumber = viewModel.getNoticeNumberFromLocal()
-
-                    val serverNewsNumber = state.data["news"]?.takeIf { it >= 0 } ?: 0
-                    val serverNoticeNumber = state.data["notice"]?.takeIf { it >= 0 } ?: 0
-
-                    if (serverNewsNumber != localNewsNumber) {
-                        Timber.tag("here").d("news server: $serverNewsNumber, local: $localNewsNumber")
-                        setBadgeOnNews(NewsTabType.NEWS.idx, true)
-                        viewModel.saveNewsNumber(serverNewsNumber)
-                    } else {
-                        Timber.tag("here").d("equal news server: $serverNewsNumber, local: $localNewsNumber")
-                    }
-
-                    if (serverNoticeNumber != localNoticeNumber) {
-                        Timber.tag("here").d("notice server: $serverNoticeNumber, local: $localNoticeNumber")
-                        setBadgeOnNews(NewsTabType.NOTICE.idx, true)
-                        viewModel.saveNoticeNumber(serverNoticeNumber)
-                    } else {
-                        Timber.tag("here").d("equal notice server: $serverNoticeNumber, local: $localNoticeNumber")
-                    }
+                    saveNumberFromServerToLocal(
+                        state.data["news"]?.takeIf { it >= 0 } ?: 0,
+                        state.data["notice"]?.takeIf { it >= 0 } ?: 0
+                    )
                 }
 
                 else -> Unit
             }
         }.launchIn(lifecycleScope)
+    }
+
+    private suspend fun saveNumberFromServerToLocal(serverNewsNumber: Int, serverNoticeNumber: Int) {
+//        viewModel.saveNewsNumber(1)
+//        viewModel.saveNoticeNumber(2)
+
+        val localNewsNumber = viewModel.getNewsNumberFromLocal()
+        val localNoticeNumber = viewModel.getNoticeNumberFromLocal()
+
+        if (serverNewsNumber > localNewsNumber) {
+            Timber.tag("here").d("news server: $serverNewsNumber, local: $localNewsNumber")
+            setBadgeOnNews(NewsTabType.NEWS.idx, true)
+            viewModel.saveNewsNumber(serverNewsNumber)
+        } else {
+            Timber.tag("here").d("equal news server: $serverNewsNumber, local: $localNewsNumber")
+        }
+
+        if (serverNoticeNumber > localNoticeNumber) {
+            Timber.tag("here").d("notice server: $serverNoticeNumber, local: $localNoticeNumber")
+            setBadgeOnNews(NewsTabType.NOTICE.idx, true)
+            viewModel.saveNoticeNumber(serverNoticeNumber)
+        } else {
+            Timber.tag("here").d("equal notice server: $serverNoticeNumber, local: $localNoticeNumber")
+        }
     }
 
     private fun setBadgeOnNews(idx: Int, isVisible: Boolean) {

--- a/feature/news/src/main/java/com/teamwable/news/NewsTabType.kt
+++ b/feature/news/src/main/java/com/teamwable/news/NewsTabType.kt
@@ -1,10 +1,8 @@
 package com.teamwable.news
 
-import androidx.annotation.StringRes
-
-enum class NewsTabType(@StringRes val idx: Int) {
-    MATCH(0),
-    RANK(1),
-    NEWS(2),
-    NOTICE(3),
+enum class NewsTabType {
+    MATCH,
+    RANK,
+    NEWS,
+    NOTICE,
 }

--- a/feature/news/src/main/java/com/teamwable/news/NewsViewModel.kt
+++ b/feature/news/src/main/java/com/teamwable/news/NewsViewModel.kt
@@ -75,5 +75,5 @@ class NewsViewModel
 
     suspend fun getNoticeNumberFromLocal() = userInfoRepository.getNoticeNumber().first()
 
-    suspend fun saveNoticeNumber(notice: Int) = userInfoRepository.saveNoticeNumber(notice)
+    suspend fun saveNoticeNumber(noticeNumber: Int) = userInfoRepository.saveNoticeNumber(noticeNumber)
 }

--- a/feature/news/src/main/java/com/teamwable/news/NewsViewModel.kt
+++ b/feature/news/src/main/java/com/teamwable/news/NewsViewModel.kt
@@ -71,9 +71,17 @@ class NewsViewModel
 
     suspend fun getNewsNumberFromLocal() = userInfoRepository.getNewsNumber().first()
 
-    suspend fun saveNewsNumber(newsNumber: Int) = userInfoRepository.saveNewsNumber(newsNumber)
+    fun saveNewsNumber(newsNumber: Int) {
+        viewModelScope.launch {
+            userInfoRepository.saveNewsNumber(newsNumber)
+        }
+    }
 
     suspend fun getNoticeNumberFromLocal() = userInfoRepository.getNoticeNumber().first()
 
-    suspend fun saveNoticeNumber(noticeNumber: Int) = userInfoRepository.saveNoticeNumber(noticeNumber)
+    fun saveNoticeNumber(noticeNumber: Int) {
+        viewModelScope.launch {
+            userInfoRepository.saveNoticeNumber(noticeNumber)
+        }
+    }
 }

--- a/feature/news/src/main/java/com/teamwable/news/NewsViewModel.kt
+++ b/feature/news/src/main/java/com/teamwable/news/NewsViewModel.kt
@@ -4,17 +4,22 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamwable.common.uistate.UiState
 import com.teamwable.data.repository.NewsRepository
+import com.teamwable.data.repository.UserInfoRepository
 import com.teamwable.model.news.NewsMatchModel
 import com.teamwable.model.news.NewsRankModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class NewsViewModel
-@Inject constructor(private val newsRepository: NewsRepository) : ViewModel() {
+@Inject constructor(
+    private val newsRepository: NewsRepository,
+    private val userInfoRepository: UserInfoRepository
+) : ViewModel() {
     private val _gameTypeUiState = MutableStateFlow<UiState<String>>(UiState.Loading)
     val gameTypeUiState = _gameTypeUiState.asStateFlow()
 
@@ -24,8 +29,12 @@ class NewsViewModel
     private val _rankUiState = MutableStateFlow<UiState<List<NewsRankModel>>>(UiState.Loading)
     val rankUiState = _rankUiState.asStateFlow()
 
+    private val _newsNumberUiState = MutableStateFlow<UiState<Map<String, Int>>>(UiState.Loading)
+    val newsNumberUiState = _newsNumberUiState.asStateFlow()
+
     init {
         getGameType()
+        getNewsNumber()
     }
 
     private fun getGameType() {
@@ -51,4 +60,20 @@ class NewsViewModel
                 .onFailure { _rankUiState.value = UiState.Failure(it.message.toString()) }
         }
     }
+
+    private fun getNewsNumber() {
+        viewModelScope.launch {
+            newsRepository.getNumber()
+                .onSuccess { _newsNumberUiState.value = UiState.Success(it) }
+                .onFailure { _newsNumberUiState.value = UiState.Failure(it.message.toString()) }
+        }
+    }
+
+    suspend fun getNewsNumberFromLocal() = userInfoRepository.getNewsNumber().first()
+
+    suspend fun saveNewsNumber(newsNumber: Int) = userInfoRepository.saveNewsNumber(newsNumber)
+
+    suspend fun getNoticeNumberFromLocal() = userInfoRepository.getNoticeNumber().first()
+
+    suspend fun saveNoticeNumber(notice: Int) = userInfoRepository.saveNoticeNumber(notice)
 }

--- a/feature/news/src/main/java/com/teamwable/news/NewsViewPagerAdapter.kt
+++ b/feature/news/src/main/java/com/teamwable/news/NewsViewPagerAdapter.kt
@@ -13,10 +13,10 @@ class NewsViewPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) 
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            NewsTabType.MATCH.idx -> NewsMatchFragment()
-            NewsTabType.RANK.idx -> NewsRankFragment()
-            NewsTabType.NEWS.idx -> NewsNewsFragment()
-            NewsTabType.NOTICE.idx -> NewsNoticeFragment()
+            NewsTabType.MATCH.ordinal -> NewsMatchFragment()
+            NewsTabType.RANK.ordinal -> NewsRankFragment()
+            NewsTabType.NEWS.ordinal -> NewsNewsFragment()
+            NewsTabType.NOTICE.ordinal -> NewsNoticeFragment()
             else -> NewsMatchFragment()
         }
     }

--- a/feature/news/src/main/java/com/teamwable/news/notice/NewsNoticeItem.kt
+++ b/feature/news/src/main/java/com/teamwable/news/notice/NewsNoticeItem.kt
@@ -2,6 +2,7 @@ package com.teamwable.news.notice
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,7 +11,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.teamwable.designsystem.theme.WableTheme
@@ -29,13 +32,29 @@ fun NewsNoticeItem(
             .clickable { onItemClick(data) }
             .padding(vertical = 12.dp, horizontal = 20.dp)
     ) {
-        Row {
-            Text(text = data.newsTitle, style = WableTheme.typography.body01)
-            Spacer(modifier = Modifier.weight(1f))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = data.newsTitle,
+                style = WableTheme.typography.body01,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
             WableNewsTimeText(data.time)
         }
         Spacer(modifier = Modifier.height(2.dp))
-        Text(text = data.newsText, color = WableTheme.colors.gray600, maxLines = 2, style = WableTheme.typography.body04)
+        Text(
+            text = data.newsText,
+            color = WableTheme.colors.gray600,
+            style = WableTheme.typography.body04,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/feature/news/src/main/java/com/teamwable/news/notice/NewsNoticeItem.kt
+++ b/feature/news/src/main/java/com/teamwable/news/notice/NewsNoticeItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -45,6 +46,7 @@ fun NewsNoticeItem(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+            Spacer(modifier = Modifier.width(10.dp))
             WableNewsTimeText(data.time)
         }
         Spacer(modifier = Modifier.height(2.dp))


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #121 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- news 페이지 뉴스, 공지사항 개수 api 구현
- news 페이지 공지사항 max line 및 SpaceBetween 적용

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/30a1d52c-9b6b-4db8-b874-facee4ea9a16

https://github.com/user-attachments/assets/d52c35da-ca1a-4681-81fc-2f517fea5c7a

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
진짜 오랜만에 개정색 빨고 한.. flow 개싫어요
![image](https://github.com/user-attachments/assets/d8fa29b6-a56b-425f-acb4-d69e734343e3)
server number가 local number보다 클 때에만 뱃지 띄우는거 맞죠?
로그는 머지 직전에 지울게요 진짜 쟤 안찍었으면 pr 못올렸음

전적으로 도움 준 찬우햄께 영광을 ^^..
소식 페이지 공지사항 title, content 원래 18, 50자 제한인데 망할 compose는 그게 쉽지 않아서 일단 maxline으로 제약 걸었어요 쩝..