### PR TITLE
[Feature/#123] : select by version, force update

### DIFF
--- a/core/ui/src/main/java/com/teamwable/ui/extensions/ContextExt.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/extensions/ContextExt.kt
@@ -146,7 +146,12 @@ fun Context.showAlertDialog(
             dialog.dismiss()
             onPositiveClick()
         }
-        .setNegativeButton(negativeButtonText) { dialog, _ -> dialog.dismiss() }
+    val isFlexibleUpdate = negativeButtonText.isNotEmpty()
+    if (isFlexibleUpdate) builder.setNegativeButton(negativeButtonText) { dialog, _ -> dialog.dismiss() }
 
-    builder.create().show()
+    builder.create().apply {
+        setCancelable(isFlexibleUpdate)
+        setCanceledOnTouchOutside(isFlexibleUpdate)
+        show()
+    }
 }

--- a/core/ui/src/main/java/com/teamwable/ui/shareAdapter/FeedClickListener.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/shareAdapter/FeedClickListener.kt
@@ -15,5 +15,5 @@ interface FeedClickListener {
 
     fun onKebabBtnClick(feed: Feed)
 
-    fun onCommentBtnClick(postAuthorNickname: String)
+    fun onCommentBtnClick(postAuthorNickname: String, feedId: Long)
 }

--- a/core/ui/src/main/java/com/teamwable/ui/shareAdapter/FeedViewHolder.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/shareAdapter/FeedViewHolder.kt
@@ -25,7 +25,7 @@ class FeedViewHolder private constructor(
         setupClickListener(binding.ivFeedProfileImg, binding.tvFeedNickname) { feedClickListener.onPostAuthorProfileClick(item.postAuthorId) }
         setupClickListener(binding.ivFeedImg) { feedClickListener.onFeedImageClick(item.image) }
         setupClickListener(binding.btnFeedMore) { feedClickListener.onKebabBtnClick(item) }
-        setupClickListener(binding.btnFeedComment) { feedClickListener.onCommentBtnClick(item.postAuthorNickname) }
+        setupClickListener(binding.btnFeedComment) { feedClickListener.onCommentBtnClick(item.postAuthorNickname, item.feedId) }
     }
 
     private fun setupClickListener(vararg views: View, action: () -> Unit) {

--- a/core/ui/src/main/res/layout/item_comment.xml
+++ b/core/ui/src/main/res/layout/item_comment.xml
@@ -84,6 +84,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
+        android:autoLink="web"
         android:textAppearance="@style/TextAppearance.Wable.Body4"
         android:textColor="@color/gray_800"
         app:layout_constraintEnd_toEndOf="@id/guideline_end"

--- a/feature/home/src/main/java/com/teamwable/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/teamwable/home/HomeFragment.kt
@@ -228,10 +228,12 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(FragmentHomeBinding::i
 
     private val requestPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
-    ) {
-        when (it) {
-            true -> handlePushAlarmPermissionGranted()
-            false -> handlePushAlarmPermissionDenied()
+    ) { isGranted ->
+        when {
+            isGranted -> handlePushAlarmPermissionGranted()
+            shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                handlePushAlarmPermissionDenied()
+            }
         }
     }
 

--- a/feature/home/src/main/java/com/teamwable/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/teamwable/home/HomeFragment.kt
@@ -134,7 +134,9 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(FragmentHomeBinding::i
             )
         }
 
-        override fun onCommentBtnClick(postAuthorNickname: String) {}
+        override fun onCommentBtnClick(postAuthorNickname: String, feedId: Long) {
+            navigateToHomeDetailFragment(feedId)
+        }
     }
 
     private fun handleProfileNavigation(id: Long) {

--- a/feature/home/src/main/java/com/teamwable/homedetail/HomeDetailFragment.kt
+++ b/feature/home/src/main/java/com/teamwable/homedetail/HomeDetailFragment.kt
@@ -234,7 +234,7 @@ class HomeDetailFragment : BindingFragment<FragmentHomeDetailBinding>(FragmentHo
             )
         }
 
-        override fun onCommentBtnClick(postAuthorNickname: String) {
+        override fun onCommentBtnClick(postAuthorNickname: String, feedId: Long) {
             handleCommentBtnClick(postAuthorNickname, CommentType.PARENT)
             viewModel.setParentCommentIds(PARENT_COMMENT_DEFAULT, PARENT_COMMENT_DEFAULT)
         }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -5,6 +5,15 @@ plugins {
 }
 android {
     namespace = "com.teamwable.main"
+
+    defaultConfig {
+        val versionCode = libs.versions.versionCode.get().toInt()
+        buildConfigField("Integer", "VERSION_CODE", "$versionCode")
+    }
+
+    buildFeatures.apply {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/feature/main/src/main/java/com/teamwable/main/AppUpdateHandler.kt
+++ b/feature/main/src/main/java/com/teamwable/main/AppUpdateHandler.kt
@@ -19,10 +19,17 @@ class AppUpdateHandler(private val appUpdateManager: AppUpdateManager) {
     }
 
     fun startUpdate(appUpdateInfo: AppUpdateInfo, activityResultLauncher: ActivityResultLauncher<IntentSenderRequest>) {
+        val appUpdateType = if (checkIsImmediate(appUpdateInfo)) AppUpdateType.IMMEDIATE else AppUpdateType.FLEXIBLE
         appUpdateManager.startUpdateFlowForResult(
             appUpdateInfo,
             activityResultLauncher,
-            AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
+            AppUpdateOptions.newBuilder(appUpdateType).build(),
         )
+    }
+
+    fun checkIsImmediate(appUpdateInfo: AppUpdateInfo): Boolean {
+        val isFirstCodeDifferent = (BuildConfig.VERSION_CODE / 100) != (appUpdateInfo.availableVersionCode() / 100)
+        val isSecondCodeDifferent = ((BuildConfig.VERSION_CODE % 100) / 10) != ((appUpdateInfo.availableVersionCode() % 100) / 10)
+        return isFirstCodeDifferent || isSecondCodeDifferent
     }
 }

--- a/feature/main/src/main/java/com/teamwable/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/teamwable/main/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity(), Navigation {
         if (state.installStatus() == InstallStatus.DOWNLOADED) {
             Timber.i("Download Complete")
             lifecycleScope.launch {
-                delay(5000)
+                delay(1000)
                 appUpdateManager.completeUpdate()
             }
         }
@@ -88,13 +88,16 @@ class MainActivity : AppCompatActivity(), Navigation {
         }
     }
 
-    private fun showUpdateDialog(appUpdateInfo: AppUpdateInfo) = showAlertDialog(
-        title = getString(R.string.label_in_app_update_title),
-        message = getString(R.string.label_in_app_update_content),
-        positiveButtonText = getString(R.string.label_in_app_update_yes),
-        negativeButtonText = getString(R.string.label_in_app_update_next),
-        onPositiveClick = { appUpdateHelper.startUpdate(appUpdateInfo, activityResultLauncher) },
-    )
+    private fun showUpdateDialog(appUpdateInfo: AppUpdateInfo) {
+        val negativeText = if (appUpdateHelper.checkIsImmediate(appUpdateInfo)) "" else getString(R.string.label_in_app_update_next)
+        showAlertDialog(
+            title = getString(R.string.label_in_app_update_title),
+            message = getString(R.string.label_in_app_update_content),
+            positiveButtonText = getString(R.string.label_in_app_update_yes),
+            negativeButtonText = negativeText,
+            onPositiveClick = { appUpdateHelper.startUpdate(appUpdateInfo, activityResultLauncher) },
+        )
+    }
 
     private fun initView() {
         setBottomNavigation()

--- a/feature/profile/src/main/java/com/teamwable/profile/profiletabs/ProfileFeedListFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profiletabs/ProfileFeedListFragment.kt
@@ -120,7 +120,7 @@ class ProfileFeedListFragment : BindingFragment<FragmentProfileFeedBinding>(Frag
             )
         }
 
-        override fun onCommentBtnClick(postAuthorNickname: String) {}
+        override fun onCommentBtnClick(postAuthorNickname: String, feedId: Long) {}
     }
 
     private fun setAdapter() {


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #123 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 버전별 선택, 강제 업데이트 분기처리 (a.b.c 중 a나 b가 변하면 강제)
- 까먹고 있었던 기능 추가..
  - 댓글에 링크 첨부 가능하도록 수정 
  - home feed에서 댓글 아이콘 클릭 시 home detail로 이동하도록 수정
- fcm 허용 안 함 분기 처리 로직 수정
  - requestPermission 에서 false 분기가 다이얼로그의 허용 안함 분기인 줄 알았는디.. 허용 안 했을 때 지속적으로 해당하는 분기더라구요.. 불필요한 api call 있어서 수정했습니다. 462bf30650150e26b9099cbab90c1d7c166e80e6 

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
#### 선택 업데이트 일 때
https://github.com/user-attachments/assets/d99a0f6d-42da-4795-83af-2ac619a124c3

#### 강제 업데이트 일 때
https://github.com/user-attachments/assets/92b53681-2ac9-4522-a1da-d2ddf24fb5a4

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
