### PR TITLE
[Feature/#139] : LCK CUP 그룹별 순위 컬러를 변경합니다. (대댓글 링크 첨부를 곁들인)

### DIFF
--- a/core/ui/src/main/java/com/teamwable/ui/type/LckCupGroup.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/type/LckCupGroup.kt
@@ -1,0 +1,11 @@
+package com.teamwable.ui.type
+
+import androidx.annotation.ColorRes
+import com.teamwable.ui.R
+
+enum class LckCupGroup(
+    @ColorRes val teamColor: Int,
+) {
+    ELDER(R.color.sky_50),
+    BARON(R.color.purple_50),
+}

--- a/core/ui/src/main/res/layout/item_child_comment.xml
+++ b/core/ui/src/main/res/layout/item_child_comment.xml
@@ -75,6 +75,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
+        android:autoLink="web"
         android:textAppearance="@style/TextAppearance.Wable.Body4"
         android:textColor="@color/gray_800"
         app:layout_constraintEnd_toEndOf="@id/guideline_end"

--- a/feature/news/src/main/java/com/teamwable/news/rank/NewsRankViewHolder.kt
+++ b/feature/news/src/main/java/com/teamwable/news/rank/NewsRankViewHolder.kt
@@ -4,6 +4,8 @@ import android.widget.ImageView
 import androidx.recyclerview.widget.RecyclerView
 import com.teamwable.model.news.NewsRankModel
 import com.teamwable.news.databinding.ItemNewsRankBinding
+import com.teamwable.ui.extensions.colorOf
+import com.teamwable.ui.type.LckCupGroup
 
 class NewsRankViewHolder(
     private val binding: ItemNewsRankBinding,
@@ -17,6 +19,9 @@ class NewsRankViewHolder(
             tvNewsRankLoss.text = data.teamDefeat.toString()
             tvNewsRankWinPercentage.text = "${data.winningRate}%"
             tvNewsRankPointDifference.text = data.scoreDiff.toString()
+            if (data.teamName in listOf("T1", "HLE", "DNF", "BRO", "BFX"))
+                setRankColor(LckCupGroup.BARON)
+            else setRankColor(LckCupGroup.ELDER)
         }
     }
 
@@ -35,5 +40,9 @@ class NewsRankViewHolder(
             else -> com.teamwable.common.R.drawable.ic_news_match_team_profile
         }
         imageView.setImageResource(resourceId)
+    }
+
+    private fun setRankColor(type: LckCupGroup) {
+        binding.tvNewsRankRank.setTextColor(itemView.context.colorOf(type.teamColor))
     }
 }


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #139 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 그룹별 순위 컬러 변경
- 대댓글 링크 첨부
- 깃헙 secret에 변경된 ip 변경

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
| 순위표 | 대댓글 링크 |
|--------|--------|
| ![KakaoTalk_20250126_203930656](https://github.com/user-attachments/assets/d604740f-60c8-461e-aa20-ba3f89d92134) | ![KakaoTalk_20250126_203927296](https://github.com/user-attachments/assets/ac785ed4-856e-4338-9117-5626d09c0d69) | 

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- dev, rel 버전 base url 모두 변경되었습니다. 슬랙 또는 노션 확인하셔서 `local.properties` 파일에 반영해주세요.


![image](https://github.com/user-attachments/assets/3c0ceff4-a80e-4b7c-add4-83fc5196c897)
