### PR TITLE
[Fix/#163] : MVI패턴에서 초기 데이터 로드 방식 수정

### DIFF
--- a/core/common/src/main/java/com/teamwable/common/base/BaseViewModel.kt
+++ b/core/common/src/main/java/com/teamwable/common/base/BaseViewModel.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -13,13 +16,23 @@ abstract class BaseViewModel<UI_INTENT : BaseIntent, UI_STATE : BaseState, SIDE_
     initialState: UI_STATE,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(initialState)
-    val uiState = _uiState.asStateFlow()
+    val uiState: StateFlow<UI_STATE> by lazy {
+        _uiState
+            .onStart { initialDataLoad() }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = initialState,
+            )
+    }
 
     private val _sideEffect: Channel<SIDE_EFFECT> = Channel(Channel.BUFFERED)
     val sideEffect = _sideEffect.receiveAsFlow()
 
     protected val currentState: UI_STATE
         get() = _uiState.value
+
+    open fun initialDataLoad() {}
 
     abstract fun onIntent(intent: UI_INTENT) // handle event from ui
 

--- a/feature/community/src/main/java/com/teamwable/community/CommunityViewModel.kt
+++ b/feature/community/src/main/java/com/teamwable/community/CommunityViewModel.kt
@@ -30,7 +30,7 @@ class CommunityViewModel @Inject constructor(
 ) : BaseViewModel<CommunityIntent, CommunityState, CommunitySideEffect>(
         initialState = CommunityState(),
     ) {
-    init {
+    override fun initialDataLoad() {
         onIntent(CommunityIntent.LoadInitialData)
     }
 


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #163 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- StateIn과 onStart 활용으로 viewmodel init에서 초기 데이터 로드하는 안티페턴 제거

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀

### 초기 데이터 로딩 init vs LaunchedEffect
즐겨보는 [유튜브 영상](https://www.youtube.com/watch?v=mNKQ9dc1knI)에서 `init`과` LaunchedEffect`를 활용한 초기 데이터 로딩이 적절하지 않다는 영상을 본 이후, 더 좋은 방식을 고민 해보았습니다.
1. **LaunchedEffect(Unit)을 사용하는 경우**, Configuration Change마다 리컴포지션이 발생하면서 매번 API를 호출하는 문제가 있습니다. 이는 명백한 안티패턴입니다.
2. **그래서 저는 개인적으로 ViewModel 내부에서 init을 활용**하는 방식을 선호했는데, 이 또한 ViewModel과 강하게 결합되어 있어 Refresh 등 데이터 로드 시점 제어에 어렵다고 하네요. 사실 이 부분은 아직 잘 모르겠습니다. ([관련 글](https://proandroiddev.com/loading-initial-data-in-launchedeffect-vs-viewmodel-f1747c20ce62))


### onStart와 StateIn 활용
onStart는 Flow가 collect되기 전에 지정된 행동을 수행하는 확장 함수입니다.
즉, stateIn을 활용해 Hot Stream으로 변환된 StateFlow가 구독되고 수집되기 전에 먼저 특정 동작을 수행한다고 이해하면 됩니다.
- MVVM 패턴에서는 UI 상태(uiState)가 ViewModel 내부에 존재하기 때문에 stateIn을 활용하는 드로이드나이트 방식을 적용할 수 있습니다.
- 하지만 MVI 패턴에서는 상태를 BaseViewModel에서 캡슐화하기 때문에 기존의 onStart + stateIn 방식을 그대로 적용하기 어려운 문제가 있었습니다.

### 참고 자료
태희님이 깃허브에 잘 정리해 두셨더라고요!
내용을 참고해서 MVI 구조에서도 onStart를 활용할 수 있도록 개선했습니다.
[사막여우님의 정리글](https://github.com/haeti-dev/Today-I-Learned/blob/main/Compose/MVI%20%ED%8C%A8%ED%84%B4%EC%97%90%EC%84%9C%20%EC%B4%88%EA%B8%B0%20%EB%8D%B0%EC%9D%B4%ED%84%B0%20%EB%A1%9C%EB%94%A9%ED%95%98%EB%8A%94%20%EC%A0%81%EC%A0%88%ED%95%9C%20%EB%B0%A9%EB%B2%95.md)