### PR TITLE
[Feature/#172] : 투명도 tooltip ui, 신고하기/투명도 이유 ui 구현

### DIFF
--- a/core/common/src/main/res/drawable/ic_info.xml
+++ b/core/common/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="13dp"
+    android:viewportWidth="12"
+    android:viewportHeight="13">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M6,6.5m-5.5,0a5.5,5.5 0,1 1,11 0a5.5,5.5 0,1 1,-11 0"
+      android:fillColor="#00000000"
+      android:strokeColor="#AEAEAE"/>
+  <path
+      android:pathData="M5.508,9.5V5.258H6.344V9.5H5.508ZM5.93,4.602C5.641,4.602 5.398,4.383 5.398,4.109C5.398,3.836 5.641,3.617 5.93,3.617C6.211,3.617 6.453,3.836 6.453,4.109C6.453,4.383 6.211,4.602 5.93,4.602Z"
+      android:fillColor="#AEAEAE"/>
+</vector>

--- a/core/common/src/main/res/drawable/ic_tooltip_triangle.xml
+++ b/core/common/src/main/res/drawable/ic_tooltip_triangle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="10dp"
+    android:viewportWidth="12"
+    android:viewportHeight="10">
+  <path
+      android:pathData="M4.268,1C5.038,-0.333 6.962,-0.333 7.732,1L11.196,7C11.966,8.333 11.004,10 9.464,10H2.536C0.996,10 0.034,8.333 0.804,7L4.268,1Z"
+      android:fillColor="#2D2D2D"/>
+</vector>

--- a/core/common/src/main/res/values/dimens.xml
+++ b/core/common/src/main/res/values/dimens.xml
@@ -5,7 +5,7 @@
     <dimen name="margin_bottom">24dp</dimen>
     <dimen name="padding_top">56dp</dimen>
     <dimen name="padding_bottom">76dp</dimen>
-    <dimen name="padding_dialog_top">32dp</dimen>
+    <dimen name="padding_dialog_top">24dp</dimen>
     <dimen name="padding_dialog_bottom">18dp</dimen>
     <dimen name="padding_touch_36">6dp</dimen>
     <dimen name="padding_touch_30">9dp</dimen>

--- a/core/data/src/main/java/com/teamwable/data/mapper/toData/PostGhostModelMapper.kt
+++ b/core/data/src/main/java/com/teamwable/data/mapper/toData/PostGhostModelMapper.kt
@@ -10,5 +10,5 @@ internal fun Ghost.toPostGhostDto(): RequestGhostDto =
         this.alarmTriggerType,
         this.postAuthorId,
         this.postId,
-        "null",
+        this.reason,
     )

--- a/core/data/src/main/java/com/teamwable/data/mapper/toData/ReportModelMapper.kt
+++ b/core/data/src/main/java/com/teamwable/data/mapper/toData/ReportModelMapper.kt
@@ -3,4 +3,4 @@ package com.teamwable.data.mapper.toData
 import com.teamwable.network.dto.request.RequestReportDto
 
 internal fun Pair<String, String>.toReportDto(): RequestReportDto =
-    RequestReportDto(first, second)
+    RequestReportDto(first, second.ifEmpty { "(없음)" })

--- a/core/model/src/main/java/com/teamwable/model/home/Ghost.kt
+++ b/core/model/src/main/java/com/teamwable/model/home/Ghost.kt
@@ -4,4 +4,5 @@ data class Ghost(
     val alarmTriggerType: String,
     val postAuthorId: Long,
     val postId: Long,
+    val reason: String = "(없음)",
 )

--- a/core/ui/src/main/java/com/teamwable/ui/component/TwoButtonDialog.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/component/TwoButtonDialog.kt
@@ -15,6 +15,7 @@ import com.teamwable.ui.databinding.DialogTwoButtonBinding
 import com.teamwable.ui.extensions.DeepLinkDestination
 import com.teamwable.ui.extensions.deepLinkNavigateTo
 import com.teamwable.ui.extensions.dialogFragmentResize
+import com.teamwable.ui.extensions.hideKeyboard
 import com.teamwable.ui.extensions.stringOf
 import com.teamwable.ui.extensions.visible
 import com.teamwable.ui.type.DialogType
@@ -26,6 +27,7 @@ class TwoButtonDialog() : BindingDialogFragment<DialogTwoButtonBinding>(DialogTw
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         val dialogTypeString = requireArguments().getString(DIALOG_TYPE)
         if (dialogTypeString != null)
             type = DialogType.valueOf(dialogTypeString)
@@ -50,6 +52,9 @@ class TwoButtonDialog() : BindingDialogFragment<DialogTwoButtonBinding>(DialogTw
         tvDialogTwoButtonTitle.setTextAppearance(type.titleTypo)
         btnDialogTwoButtonYes.text = stringOf(type.yesLabel)
         btnDialogTwoButtonNo.text = stringOf(type.noLabel)
+        layoutDialogTwoButtonReason.visible(stringOf(type.reason).isNotEmpty())
+        etDialogTwoButtonReason.hint = stringOf(type.reason)
+        binding.root.apply { setOnClickListener { context.hideKeyboard(it) } }
     }
 
     private fun initNoBtnClickListener() {
@@ -72,7 +77,10 @@ class TwoButtonDialog() : BindingDialogFragment<DialogTwoButtonBinding>(DialogTw
                 else -> Unit
             }
 
-            val result = Bundle().apply { putString(DIALOG_TYPE, type.name) }
+            val result = Bundle().apply {
+                putString(DIALOG_TYPE, type.name)
+                putString(DIALOG_RESULT, binding.etDialogTwoButtonReason.text.toString())
+            }
             setFragmentResult(DIALOG_RESULT, result)
             findNavController().popBackStack()
         }

--- a/core/ui/src/main/java/com/teamwable/ui/type/DialogType.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/type/DialogType.kt
@@ -10,12 +10,14 @@ enum class DialogType(
     @StringRes val noLabel: Int = R.string.label_dialog_share_no,
     @StringRes val yesLabel: Int = R.string.label_dialog_delete_yes,
     @StyleRes val titleTypo: Int = R.style.TextAppearance_Wable_Head2,
+    @StringRes val reason: Int = R.string.label_dialog_blank,
 ) {
     REPORT(
         title = R.string.label_dialog_report_title,
-        description = R.string.label_dialog_report_description,
+        noLabel = R.string.label_dialog_transparency_no,
         yesLabel = R.string.label_dialog_report_yes,
         titleTypo = R.style.TextAppearance_Wable_Head1,
+        reason = R.string.hint_dialog_report_reason,
     ),
     BAN(
         title = R.string.label_dialog_ban_title,
@@ -44,6 +46,7 @@ enum class DialogType(
         title = R.string.label_dialog_transparency_title,
         noLabel = R.string.label_dialog_transparency_no,
         yesLabel = R.string.label_dialog_transparency_yes,
+        reason = R.string.hint_dialog_transparency_reason,
     ),
     CANCEL_POSTING(
         title = R.string.label_dialog_cancel_posting_title,

--- a/core/ui/src/main/java/com/teamwable/ui/util/CommentActionHandler.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/util/CommentActionHandler.kt
@@ -41,12 +41,12 @@ class CommentActionHandler(
             ProfileUserType.ADMIN -> navigateToTwoLabelBottomSheet(BottomSheetType.REPORT, BottomSheetType.BAN)
             ProfileUserType.EMPTY -> return
         }
-        handleDialogResult { dialogType ->
+        handleDialogResult { dialogType, reason ->
             when (dialogType) {
                 DialogType.DELETE_COMMENT -> removeComment(comment.commentId)
                 DialogType.REPORT -> {
                     navController.popBackStack()
-                    reportUser(comment.postAuthorNickname, comment.content)
+                    reportUser(comment.postAuthorNickname, reason)
                 }
 
                 DialogType.BAN -> {
@@ -59,12 +59,12 @@ class CommentActionHandler(
         }
     }
 
-    fun onGhostBtnClick(type: DialogType, updateGhost: () -> Unit) {
+    fun onGhostBtnClick(type: DialogType, updateGhost: (String) -> Unit) {
         trackEvent(CLICK_GHOST_COMMENT)
         navigateToDialog(type)
-        handleDialogResult { dialogType ->
+        handleDialogResult { dialogType, reason ->
             when (dialogType) {
-                DialogType.TRANSPARENCY -> updateGhost()
+                DialogType.TRANSPARENCY -> updateGhost(reason)
                 else -> Unit
             }
         }
@@ -107,10 +107,10 @@ class CommentActionHandler(
         TwoButtonDialog.show(context, navController, type)
     }
 
-    private fun handleDialogResult(onResult: (DialogType) -> Unit) {
+    private fun handleDialogResult(onResult: (DialogType, String) -> Unit) {
         fragmentManager.setFragmentResultListener(DIALOG_RESULT, lifecycleOwner) { _, bundle ->
             val dialogType = DialogType.valueOf(bundle.getString(DIALOG_TYPE) ?: return@setFragmentResultListener)
-            onResult(dialogType)
+            onResult(dialogType, bundle.getString(DIALOG_RESULT).orEmpty())
         }
     }
 }

--- a/core/ui/src/main/java/com/teamwable/ui/util/Constants.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/util/Constants.kt
@@ -17,6 +17,7 @@ object Arg {
     const val PROFILE_EDIT_RESULT = "profile_edit_result"
     const val BOTTOM_SHEET_FIRST_TYPE = "bottom_sheet_first_type"
     const val BOTTOM_SHEET_SECOND_TYPE = "bottom_sheet_second_type"
+    const val DIALOG_REASON = "dialog_reason"
 }
 
 object BundleKey {

--- a/core/ui/src/main/java/com/teamwable/ui/util/FeedActionHandler.kt
+++ b/core/ui/src/main/java/com/teamwable/ui/util/FeedActionHandler.kt
@@ -45,7 +45,7 @@ class FeedActionHandler(
             ProfileUserType.ADMIN -> navigateToTwoLabelBottomSheet(BottomSheetType.REPORT, BottomSheetType.BAN)
             ProfileUserType.EMPTY -> return
         }
-        handleDialogResult { dialogType ->
+        handleDialogResult { dialogType, reason ->
             when (dialogType) {
                 DialogType.DELETE_FEED -> {
                     trackEvent(CLICK_DELETE_POST)
@@ -54,7 +54,7 @@ class FeedActionHandler(
 
                 DialogType.REPORT -> {
                     navController.popBackStack()
-                    reportUser(feed.postAuthorNickname, "${feed.title}\n${feed.content}")
+                    reportUser(feed.postAuthorNickname, reason)
                 }
 
                 DialogType.BAN -> {
@@ -67,12 +67,12 @@ class FeedActionHandler(
         }
     }
 
-    fun onGhostBtnClick(type: DialogType, updateGhost: () -> Unit) {
+    fun onGhostBtnClick(type: DialogType, updateGhost: (String) -> Unit) {
         trackEvent(CLICK_GHOST_POST)
         navigateToDialog(type)
-        handleDialogResult { dialogType ->
+        handleDialogResult { dialogType, reason ->
             when (dialogType) {
-                DialogType.TRANSPARENCY -> updateGhost()
+                DialogType.TRANSPARENCY -> updateGhost(reason)
                 else -> Unit
             }
         }
@@ -120,10 +120,10 @@ class FeedActionHandler(
         TwoButtonDialog.show(context, navController, type)
     }
 
-    private fun handleDialogResult(onResult: (DialogType) -> Unit) {
+    private fun handleDialogResult(onResult: (DialogType, String) -> Unit) {
         fragmentManager.setFragmentResultListener(DIALOG_RESULT, lifecycleOwner) { _, bundle ->
             val dialogType = DialogType.valueOf(bundle.getString(DIALOG_TYPE) ?: return@setFragmentResultListener)
-            onResult(dialogType)
+            onResult(dialogType, bundle.getString(DIALOG_RESULT).orEmpty())
         }
     }
 }

--- a/core/ui/src/main/res/layout/dialog_two_button.xml
+++ b/core/ui/src/main/res/layout/dialog_two_button.xml
@@ -32,20 +32,52 @@
         app:layout_constraintTop_toBottomOf="@id/tv_dialog_two_button_title"
         tools:text="description" />
 
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/layout_dialog_two_button_reason"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:boxBackgroundColor="@color/gray_100"
+        app:boxStrokeWidth="0dp"
+        app:boxStrokeWidthFocused="0dp"
+        app:counterEnabled="true"
+        app:counterMaxLength="100"
+        app:counterTextAppearance="@style/TextAppearance.Wable.Caption4"
+        app:counterTextColor="@color/gray_600"
+        app:layout_constraintDimensionRatio="267:177"
+        app:layout_constraintEnd_toEndOf="@id/tv_dialog_two_button_title"
+        app:layout_constraintStart_toStartOf="@id/tv_dialog_two_button_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_dialog_two_button_description"
+        app:shapeAppearance="@style/WableRounded12">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_dialog_two_button_reason"
+            style="@style/TextAppearance.Wable.Body4"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="top"
+            android:maxLength="100"
+            android:minLines="6"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="12dp"
+            android:textColorHint="@color/gray_600" />
+    </com.google.android.material.textfield.TextInputLayout>
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_dialog_two_button_no"
         style="@style/Wable.Button.M.S"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="18dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="16dp"
         android:layout_marginEnd="4dp"
         android:backgroundTint="@color/gray_200"
         android:textColor="@color/gray_600"
         app:layout_constraintDimensionRatio="2.6"
         app:layout_constraintEnd_toStartOf="@id/btn_dialog_two_button_yes"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_dialog_two_button_description"
+        app:layout_constraintTop_toBottomOf="@id/layout_dialog_two_button_reason"
         tools:text="no" />
 
     <com.google.android.material.button.MaterialButton

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -10,8 +10,7 @@
     <string name="tv_calculate_time_year">년 전</string>
 
     <!-- dialog -->
-    <string name="label_dialog_report_title">신고하시겠어요?</string>
-    <string name="label_dialog_report_description">해당 유저 혹은 게시글을 신고하시려면 신고하기 버튼을 눌러주세요.</string>
+    <string name="label_dialog_report_title">신고하기</string>
     <string name="label_dialog_report_yes">신고하기</string>
     <string name="label_dialog_delete_feed_title">게시글을 삭제하시겠어요?</string>
     <string name="label_dialog_delete_feed_description">게시글이 영구히 삭제됩니다.</string>
@@ -21,8 +20,8 @@
     <string name="label_dialog_delete_account_title">계정을 삭제하시겠어요?</string>
     <string name="label_dialog_logout_title">로그아웃하시겠어요?</string>
     <string name="label_dialog_logout_yes">로그아웃하기</string>
-    <string name="label_dialog_transparency_title">와블의 온화한 문화를 해치는\n누군가를 발견하신 건가요?</string>
-    <string name="label_dialog_transparency_yes">네 맞아요</string>
+    <string name="label_dialog_transparency_title">와블의 온화함을 해치는\n누군가를 발견하신건가요?</string>
+    <string name="label_dialog_transparency_yes">투명도 내리기</string>
     <string name="label_dialog_transparency_no">고민할게요</string>
     <string name="label_dialog_cancel_posting_title">작성중인 글에서 나가실건가요?\n작성하셨던 내용은 삭제돼요</string>
     <string name="label_dialog_cancel_posting__yes">나가기</string>
@@ -31,6 +30,8 @@
     <string name="label_dialog_ban_title">밴하시겠어요?</string>
     <string name="label_dialog_ban_description">1회 누적 - 해당 글(게시글 or 댓글 or 답글)만 블라인드 처리\n2회 누적 - 해당 사용자 글 전체 블라인드 처리</string>
     <string name="label_dialog_ban_yes">밴하기</string>
+    <string name="hint_dialog_transparency_reason">투명도를 내리려는 이유가 무엇인가요?\nex. 선수를 비하했어요</string>
+    <string name="hint_dialog_report_reason">신고하시려는 사유를 알려주시면 더 건강한 문화를 만드는 것에 도움돼요.\n사유는 생략 가능해요.</string>
 
     <!-- feed -->
     <string name="content_description_feed_image">피드 이미지입니다.</string>

--- a/core/ui/src/main/res/values/styles.xml
+++ b/core/ui/src/main/res/values/styles.xml
@@ -67,4 +67,8 @@
     <style name="WableRoundedImage8">
         <item name="cornerSize">8dp</item>
     </style>
+
+    <style name="WableRounded12">
+        <item name="cornerSize">12dp</item>
+    </style>
 </resources>

--- a/feature/home/src/main/java/com/teamwable/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/teamwable/home/HomeFragment.kt
@@ -127,8 +127,8 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(FragmentHomeBinding::i
         }
 
         override fun onGhostBtnClick(postAuthorId: Long, feedId: Long) {
-            feedActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) {
-                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.CONTENT.type), postAuthorId, feedId))
+            feedActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) { reason ->
+                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.CONTENT.type), postAuthorId, feedId, reason))
             }
         }
 

--- a/feature/home/src/main/java/com/teamwable/homedetail/HomeDetailFragment.kt
+++ b/feature/home/src/main/java/com/teamwable/homedetail/HomeDetailFragment.kt
@@ -210,8 +210,8 @@ class HomeDetailFragment : BindingFragment<FragmentHomeDetailBinding>(FragmentHo
         }
 
         override fun onGhostBtnClick(postAuthorId: Long, feedId: Long) {
-            feedActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) {
-                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.CONTENT.type), postAuthorId, feedId))
+            feedActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) { reason ->
+                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.CONTENT.type), postAuthorId, feedId, reason))
             }
         }
 

--- a/feature/main/src/main/java/com/teamwable/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/teamwable/main/MainActivity.kt
@@ -211,13 +211,25 @@ class MainActivity : AppCompatActivity(), Navigation {
             com.teamwable.ui.R.id.navigation_feed_image_dialog,
         )
 
+        val noStatusBarChangeDestinations = setOf(
+            com.teamwable.ui.R.id.navigation_two_button_dialog,
+            com.teamwable.ui.R.id.navigation_bottomSheet,
+            com.teamwable.ui.R.id.navigation_two_label_bottomsheet,
+        )
+
         navController.addOnDestinationChangedListener { _, destination, _ ->
-            if (destination.id in darkStatusBarDestinations) {
-                statusBarColorOf(com.teamwable.ui.R.color.black)
-                statusBarModeOf(false)
-            } else {
-                statusBarColorOf(com.teamwable.ui.R.color.white)
-                statusBarModeOf()
+            when (destination.id) {
+                in darkStatusBarDestinations -> {
+                    statusBarColorOf(com.teamwable.ui.R.color.black)
+                    statusBarModeOf(false)
+                }
+
+                in noStatusBarChangeDestinations -> Unit
+
+                else -> {
+                    statusBarColorOf(com.teamwable.ui.R.color.white)
+                    statusBarModeOf()
+                }
             }
         }
     }

--- a/feature/profile/src/main/java/com/teamwable/profile/component/GhostInfo.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/component/GhostInfo.kt
@@ -1,0 +1,161 @@
+package com.teamwable.profile.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
+import com.teamwable.designsystem.extension.composable.toImageVector
+import com.teamwable.designsystem.extension.modifier.noRippleClickable
+import com.teamwable.designsystem.theme.WableTheme
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GhostInfoTooltip(
+    modifier: Modifier = Modifier,
+) {
+    val tooltipState = rememberTooltipState()
+    val scope = rememberCoroutineScope()
+
+    TooltipBox(
+        modifier = modifier,
+        positionProvider = createCustomPositionProvider(19.dp),
+        tooltip = {
+            Column(
+                modifier = Modifier
+                    .padding(start = 16.dp, end = 82.dp),
+            ) {
+                Icon(
+                    imageVector = toImageVector(
+                        id = com.teamwable.common.R.drawable.ic_tooltip_triangle,
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(start = 20.dp)
+                        .offset(y = 4.dp),
+                )
+
+                Text(
+                    text = createTooltipText(),
+                    color = WableTheme.colors.gray200,
+                    style = WableTheme.typography.caption03,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(WableTheme.colors.gray900)
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                )
+            }
+        },
+        state = tooltipState,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "투명도",
+                style = WableTheme.typography.caption01,
+            )
+
+            Spacer(modifier = Modifier.width(2.dp))
+
+            Icon(
+                imageVector = toImageVector(
+                    id = com.teamwable.common.R.drawable.ic_info,
+                ),
+                tint = Color.Unspecified,
+                contentDescription = "투명도 툴팁 보기",
+                modifier = Modifier.noRippleClickable {
+                    scope.launch {
+                        if (tooltipState.isVisible) {
+                            tooltipState.dismiss()
+                        } else {
+                            tooltipState.show()
+                        }
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+fun createCustomPositionProvider(spacing: Dp = 8.dp): PopupPositionProvider {
+    val density = LocalDensity.current
+
+    return remember(spacing, density) {
+        object : PopupPositionProvider {
+            override fun calculatePosition(
+                anchorBounds: IntRect,
+                windowSize: IntSize,
+                layoutDirection: LayoutDirection,
+                popupContentSize: IntSize,
+            ): IntOffset {
+                val spacingPx = with(density) { spacing.roundToPx() }
+                val x = anchorBounds.left
+                val y = anchorBounds.bottom + spacingPx
+
+                return IntOffset(x, y)
+            }
+        }
+    }
+}
+
+@Composable
+fun createTooltipText(): AnnotatedString {
+    return buildAnnotatedString {
+        withStyle(style = SpanStyle(color = WableTheme.colors.sky50)) {
+            append("투명도란? ")
+        }
+
+        withStyle(style = SpanStyle(color = WableTheme.colors.gray200)) {
+            append("설명 어쩌고 저쩌고 어쩌고 저쩌고 어쩌고 저쩌고 어쩌고 저쩌고...")
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    group = "ProfileComponent",
+)
+@Composable
+private fun GhostInfoTooltipPreview() {
+    WableTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp),
+        ) {
+            GhostInfoTooltip()
+        }
+    }
+}

--- a/feature/profile/src/main/java/com/teamwable/profile/profile/BindingProfileFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profile/BindingProfileFragment.kt
@@ -6,11 +6,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorRes
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.appbar.AppBarLayout
+import com.teamwable.designsystem.theme.WableTheme
 import com.teamwable.model.Profile
 import com.teamwable.profile.R
+import com.teamwable.profile.component.GhostInfoTooltip
 import com.teamwable.profile.databinding.FragmentProfileBinding
 import com.teamwable.ui.extensions.colorOf
 import com.teamwable.ui.extensions.load
@@ -50,6 +56,22 @@ abstract class BindingProfileFragment : Fragment() {
         tvProfileLevel.text = getString(R.string.label_profile_level, data.level)
         setSwipeLayout()
         setGhostProgress(data.ghost)
+        initComposeView()
+    }
+
+    private fun initComposeView() {
+        binding.cvProfileGhostLabel.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WableTheme {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        GhostInfoTooltip()
+                    }
+                }
+            }
+        }
     }
 
     private fun setSwipeLayout() {

--- a/feature/profile/src/main/java/com/teamwable/profile/profiletabs/ProfileCommentListFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profiletabs/ProfileCommentListFragment.kt
@@ -87,8 +87,8 @@ class ProfileCommentListFragment : BindingFragment<FragmentProfileCommentBinding
 
     private fun onClickCommentItem() = object : CommentClickListener {
         override fun onGhostBtnClick(postAuthorId: Long, commentId: Long) {
-            commentActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) {
-                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.COMMENT.type), postAuthorId, commentId))
+            commentActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) { reason ->
+                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.COMMENT.type), postAuthorId, commentId, reason))
             }
         }
 

--- a/feature/profile/src/main/java/com/teamwable/profile/profiletabs/ProfileFeedListFragment.kt
+++ b/feature/profile/src/main/java/com/teamwable/profile/profiletabs/ProfileFeedListFragment.kt
@@ -94,8 +94,8 @@ class ProfileFeedListFragment : BindingFragment<FragmentProfileFeedBinding>(Frag
         }
 
         override fun onGhostBtnClick(postAuthorId: Long, feedId: Long) {
-            feedActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) {
-                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.CONTENT.type), postAuthorId, feedId))
+            feedActionHandler.onGhostBtnClick(DialogType.TRANSPARENCY) { reason ->
+                viewModel.updateGhost(Ghost(stringOf(AlarmTriggerType.CONTENT.type), postAuthorId, feedId, reason))
             }
         }
 

--- a/feature/profile/src/main/res/layout/fragment_profile.xml
+++ b/feature/profile/src/main/res/layout/fragment_profile.xml
@@ -132,16 +132,6 @@
                             app:layout_constraintTop_toBottomOf="@id/iv_profile_info_triangle"
                             tools:text="@string/label_profile_info" />
 
-                        <TextView
-                            android:id="@+id/tv_profile_ghost_label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="12dp"
-                            android:text="@string/label_profile_ghost"
-                            android:textAppearance="@style/TextAppearance.Wable.Caption1"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/tv_profile_info" />
-
                         <ImageView
                             android:id="@+id/iv_profile_ghost_icon"
                             android:layout_width="wrap_content"
@@ -167,13 +157,12 @@
                             android:id="@+id/progress_profile_ghost"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="5dp"
                             android:progress="0"
                             app:indicatorColor="@color/purple_50"
                             app:indicatorTrackGapSize="0dp"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/tv_profile_ghost_label"
+                            app:layout_constraintTop_toBottomOf="@id/cv_profile_ghost_label"
                             app:trackColor="@color/gray_200"
                             app:trackCornerRadius="8dp"
                             app:trackStopIndicatorSize="0dp"
@@ -198,6 +187,16 @@
                             android:src="@drawable/ic_profile_badge"
                             app:layout_constraintStart_toStartOf="@id/tv_profile_badge_label"
                             app:layout_constraintTop_toBottomOf="@id/tv_profile_badge_label" />
+
+                        <androidx.compose.ui.platform.ComposeView
+                            android:id="@+id/cv_profile_ghost_label"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="7dp"
+                            android:paddingTop="5dp"
+                            android:paddingBottom="5dp"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/tv_profile_info" />
                     </androidx.constraintlayout.widget.ConstraintLayout>
                 </com.google.android.material.appbar.MaterialToolbar>
 


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- P1 단계의 리뷰는 필수로 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #172 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 투명도 tooltip ui 구현
- Tooltip ui를 compose로 구현했습니다. dismiss는 2가지 방식으로 가능합니다. 1) 1.5초 뒤 자동 종료 2) tooltip 이외의 영역 클릭 시 바로 종료
- [x] 신고하기/투명도 다이얼로그에 이유 추가
- 기존의 다이얼로그 컴포넌트(XML)에 이유를 작성 할 수 있도록 수정했습니다.
- [x] 서버에 이유 보낼 수 있도록 수정

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
#### Tooltip
https://github.com/user-attachments/assets/3f51fda2-0c55-4c1c-8e90-6d208bb1672b

#### 다이얼로그
https://github.com/user-attachments/assets/3b60b187-9eee-4c99-a5a2-b25c96e23908

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- tooltip의 내용은 정해지면 반영하겠습니다!